### PR TITLE
Replace Grafana variables in queries.

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -75,7 +75,8 @@ export class SiriDBDatasource {
     let promises = [];
 
     targets.forEach(t => {
-      let query = this.buildSiriDBQuery(t, start, end, options.maxDataPoints);
+      var query = this.buildSiriDBQuery(t, start, end, options.maxDataPoints);
+      query = this.templateSrv.replace(query, options.scopedVars, 'regex');
 
       promises.push(this.backendSrv.datasourceRequest({
         url: this.url + '/query',


### PR DESCRIPTION
This allows the use of `$__interval` / `$__interval_ms` in queries and also dashboard variables.